### PR TITLE
Add Prism dependency for older Ruby versions

### DIFF
--- a/aye_var.gemspec
+++ b/aye_var.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
 
 	spec.metadata["rubygems_mfa_required"] = "true"
 	spec.add_dependency "require-hooks"
+	spec.add_dependency "prism"
 end


### PR DESCRIPTION
For < 3.2