### PR TITLE
Support shorthand ivar string interpolation

### DIFF
--- a/lib/strict_ivars/processor.rb
+++ b/lib/strict_ivars/processor.rb
@@ -54,6 +54,20 @@ class StrictIvars::Processor < StrictIvars::BaseProcessor
 		super
 	end
 
+	#: (Prism::EmbeddedVariableNode) -> void
+	def visit_embedded_variable_node(node)
+		variable = node.variable
+
+		return super unless Prism::InstanceVariableReadNode === variable
+		return super if @context.include?(variable.name)
+
+		location = variable.location
+		annotations = @annotations
+		annotations.push([location.start_character_offset, "{"])
+		super
+		annotations.push([location.end_character_offset, "}"])
+	end
+
 	#: (Prism::InstanceVariableReadNode) -> void
 	def visit_instance_variable_read_node(node)
 		name = node.name

--- a/test/eval.test.rb
+++ b/test/eval.test.rb
@@ -23,3 +23,11 @@ test "eval with implicit path" do
 		RUBY
 	end
 end
+
+test "eval with shorthand string interpolation" do
+	assert_raises StrictIvars::NameError do
+		eval <<~'RUBY', binding, __FILE__, __LINE__ + 1
+			"hello #@name"
+		RUBY
+	end
+end

--- a/test/processor.test.rb
+++ b/test/processor.test.rb
@@ -264,6 +264,36 @@ test "singleton class isolation" do
 	RUBY
 end
 
+test "shorthand string interpolation" do
+	processed = StrictIvars::Processor.call(<<~'RUBY')
+		def foo
+			"hello #@name"
+		end
+	RUBY
+
+	assert_equal_ruby processed, <<~RUBY
+		def foo
+			"hello #\{#{guarded(:@name)}}"
+		end
+	RUBY
+end
+
+test "in context shorthand string interpolation" do
+	processed = StrictIvars::Processor.call(<<~'RUBY')
+		def foo
+			@name ||= "world"
+			"hello \#@name"
+		end
+	RUBY
+
+	assert_equal_ruby processed, <<~'RUBY'
+		def foo
+			@name ||= "world"
+			"hello \#@name"
+		end
+	RUBY
+end
+
 def guarded(name)
 	"(defined?(#{name.name}) ? #{name.name} : (::Kernel.raise(::StrictIvars::NameError.new(self, :#{name.name}))))"
 end


### PR DESCRIPTION
Currently strict_ivars will produce incorrect code if it encounters an embedded variable node:

```rb
"#@foo"
```
will become
```rb
"#(defined?(@foo) ? @foo : (::Kernel.raise(::StrictIvars::NameError.new(self, :@foo))))"
# ^ no { so no interpolation
```

Here's the situation where I noticed this was happening:
<img width="2520" height="668" alt="CleanShot 2026-01-05 at 14 56 30@2x" src="https://github.com/user-attachments/assets/8ba219a1-4c6a-4d7e-a29c-39d9ef098e9a" />

I added test cases, and a visitor for the EmbeddedVariableNode. I also added an early return if the variable is already in context. But it's not strictly required, it just seemed like a nice thing to do 🤷‍♂️